### PR TITLE
unix to linux

### DIFF
--- a/skidscan/Cargo.toml
+++ b/skidscan/Cargo.toml
@@ -18,5 +18,5 @@ obfstr = { version = "0.3", optional = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.9", features = ["libloaderapi", "processthreadsapi", "psapi", "minwindef"] }
 
-[target.'cfg(target_os = "unix")'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
error[E0432]: unresolved import libc
  |
6 | use libc::{dl_iterate_phdr, dl_phdr_info, PT_LOAD};
  |     ^^^^ use of undeclared crate or module libc

error[E0433]: failed to resolve: use of undeclared crate or module libc
   |
23 | type Phdr = libc::Elf64_Phdr;
   |             ^^^^ use of undeclared crate or module libc

Some errors have detailed explanations: E0432, E0433.
For more information about an error, try rustc --explain E0432.
error: could not compile skidscan due to 2 previous errors

Using this change works fine for me